### PR TITLE
Add JitPack Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,51 @@ for (var sb = new StringBuilder(" "); (tokens = tokenizer.encode(sb)).size() == 
 `                                                                                 `'s token is [96529], and that's 81 spaces!
 ```
 
+## Maven/Gradle Usage
+
+This project is hosted on JitPack, which means you can add it as a dependency in your Maven or Gradle project directly.
+
+### Maven
+
+Add the JitPack repository to your `pom.xml`:
+
+```xml
+<repositories>
+    <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+    </repository>
+</repositories>
+```
+
+Then add the dependency:
+
+```xml
+<dependency>
+    <groupId>com.github.didalgolab</groupId>
+    <artifactId>gpt3-tokenizer-java</artifactId>
+    <version>main-SNAPSHOT</version>
+</dependency>
+```
+
+### Gradle
+
+Add the JitPack repository to your `build.gradle`:
+
+```gradle
+repositories {
+    maven { url 'https://jitpack.io' }
+}
+```
+
+Then add the dependency:
+
+```gradle
+dependencies {
+    implementation 'com.github.didalgolab:gpt3-tokenizer-java:main-SNAPSHOT'
+}
+```
+
 ## License
 
 This project is licensed under the MIT License.

--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ publishing {
 }
 
 signing {
+    required { gradle.taskGraph.hasTask("publish") }
     sign publishing.publications.mavenJava
 }
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk21

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk21
+  - openjdk17


### PR DESCRIPTION
This pull request adds support for JitPack.

This allows other developers to easily use this project as a dependency in their Maven or Gradle projects.

To use this project as a dependency, add the following to your `build.gradle`:

```gradle
dependencies {
    implementation 'com.github.kamilake:gpt3-tokenizer-java:main-SNAPSHOT'
}
```
This pull request makes it easier for other developers to use this project, and it improves the project's overall accessibility.
